### PR TITLE
remove workaround for a login shell xonsh (fixed upstream)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except (IOError, OSError):
 
 setuptools.setup(
     name='xontrib-zoxide',
-    version='0.2.0',
+    version='0.3.0',
     license='MIT',
     author='Gyuri Horak',
     author_email='dyuri@horak.hu',

--- a/xontrib/zoxide.xsh
+++ b/xontrib/zoxide.xsh
@@ -4,5 +4,4 @@ import xonsh
 __all__ = ()
 
 
-with ${...}.swap(UPDATE_OS_ENVIRON=True):
-    execx($(zoxide init xonsh), 'exec', __xonsh__.ctx, filename='zoxide')
+execx($(zoxide init xonsh), 'exec', __xonsh__.ctx, filename='zoxide')


### PR DESCRIPTION
https://github.com/dyuri/xontrib-zoxide/issues/1 is fixed upstream, so the workaround isn't needed anymore

Also this workaround now seems to introduce another weird interaction issue between itself and [back2dir](https://github.com/anki-code/xontrib-back2dir), where sometimes (e.g. during launch) when pressing <kbd>Up</kbd> on a new empty prompt line I get `[A`  symbols in Windows (but only during the first second or so, if I wait a bit nothing happens, I cycle through history as usual)
Without the workaround everything seems to behave just fine without those `[A`s