### PR TITLE
Put zcache in XDG_CACHE_HOME if it exists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name       	= "xontrib-zoxide"
-version    	= "1.0.0"
+version    	= "1.1.0"
 description	= "Zoxide integration for xonsh"
 authors    	= ["Gyuri Horak <dyuri@horak.hu>"]
 license    	= "MIT"

--- a/xontrib/zoxide/zoxide.py
+++ b/xontrib/zoxide/zoxide.py
@@ -18,9 +18,9 @@ def _cache_zoxide_init(zoxide_init, z_cache_path):
 
 def  _initZoxide():
   if cache_home := os.environ.get("XDG_CACHE_HOME"):
-    z_cache_path = pathlib.Path(cache_home).expanduser() / "zoxide" / _cache_name
+    z_cache_path = Path(cache_home).expanduser() / "zoxide" / _cache_name
   else:
-    z_cache_path	= pathlib.Path(os.path.dirname(__file__)).parent / _cache_name
+    z_cache_path	= Path(os.path.dirname(__file__)).parent / _cache_name
   sys.path.append(str(z_cache_path.parent))
 
   zoxide_init_proc	= subprocess.run(["zoxide",'init','xonsh'],capture_output=True)

--- a/xontrib/zoxide/zoxide.py
+++ b/xontrib/zoxide/zoxide.py
@@ -19,6 +19,7 @@ def _cache_zoxide_init(zoxide_init, z_cache_path):
 def  _initZoxide():
   if cache_home := os.environ.get("XDG_CACHE_HOME"):
     z_cache_path = Path(cache_home).expanduser() / "zoxide" / _cache_name
+    z_cache_path.parent.mkdir(exist_ok=True, parents=True)
   else:
     z_cache_path	= Path(os.path.dirname(__file__)).parent / _cache_name
   sys.path.append(str(z_cache_path.parent))


### PR DESCRIPTION
Resolves #5, by using `$XDG_CACHE_HOME` if it exists for the zoxide cache. If not the current behavior prevails, using the dir containing `__file__`.